### PR TITLE
added header to allow CORS access for any domain to Auto Authenticati…

### DIFF
--- a/src/main/java/com/haxwell/apps/questions/servlets/filters/AutoAuthenticateUserFilter.java
+++ b/src/main/java/com/haxwell/apps/questions/servlets/filters/AutoAuthenticateUserFilter.java
@@ -47,6 +47,9 @@ public class AutoAuthenticateUserFilter extends AbstractFilter {
 	 */
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		HttpSession session = ((HttpServletRequest)request).getSession();
+		HttpServletResponse hsr = (HttpServletResponse)response;
+		
+		hsr.addHeader("Access-Control-Allow-Origin", "*");
 
 		if (session.getAttribute(Constants.IN_PRODUCTION_MODE) == null) {
 			// TODO: get these from Spring instead
@@ -57,7 +60,7 @@ public class AutoAuthenticateUserFilter extends AbstractFilter {
 		}
 		
 		// pass the request along the filter chain
-		chain.doFilter(request, response);
+		chain.doFilter(request, hsr);
 	}
 
 }

--- a/src/main/java/com/haxwell/apps/questions/servlets/filters/AutoAuthenticateUserFilter.java
+++ b/src/main/java/com/haxwell/apps/questions/servlets/filters/AutoAuthenticateUserFilter.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+
 import com.haxwell.apps.questions.constants.Constants;
 import com.haxwell.apps.questions.servlets.actions.LoginWithTheRequestCredentialsAction;
 
@@ -47,9 +48,11 @@ public class AutoAuthenticateUserFilter extends AbstractFilter {
 	 */
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		HttpSession session = ((HttpServletRequest)request).getSession();
-		HttpServletResponse hsr = (HttpServletResponse)response;
+		HttpServletResponse res = (HttpServletResponse) response;
 		
-		hsr.addHeader("Access-Control-Allow-Origin", "*");
+		//allow cross origin access for Quizki-frontend access temporarily in classic version
+		res.addHeader("Access-Control-Allow-Origin", "*");
+		res.addHeader("content-type", "text/plain" );
 
 		if (session.getAttribute(Constants.IN_PRODUCTION_MODE) == null) {
 			// TODO: get these from Spring instead
@@ -60,7 +63,7 @@ public class AutoAuthenticateUserFilter extends AbstractFilter {
 		}
 		
 		// pass the request along the filter chain
-		chain.doFilter(request, hsr);
+		chain.doFilter(request, response);
 	}
 
 }


### PR DESCRIPTION
…on filter

Checking the Response with Postman I can see the new header is present when requesting a login. So this code is working. (and doesn't seem to have broken anything else)

Still problems on the angular end. I think that the "originallyRequestedPage" referenced on line 117 of LoginServlet.java is probably null since I'm not accessing this in the normal flow.

I get this new error...

_**The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.**_

Which I think means that Quizki is not returning anything with the Response. I suppose I could try a dummy call from the front end to the profile page and then throw it away??? or put some code in Quizki to return the profile page in the event "originallyRequestedPage" property in the session is null??? What do you think? (I might get some question Id's this way)